### PR TITLE
Cleaned up token creation and refreshing

### DIFF
--- a/app/controllers/skydrive/application_controller.rb
+++ b/app/controllers/skydrive/application_controller.rb
@@ -38,11 +38,7 @@ module Skydrive
     end
 
     def skydrive_client
-      @skydrive_client ||=
-          Client.new(SHAREPOINT.merge(
-                         personal_url: current_user.token.personal_url,
-                         token: current_user.token.access_token
-                     ))
+      @skydrive_client ||= current_user.skydrive_client
     end
   end
 end

--- a/app/models/skydrive/token.rb
+++ b/app/models/skydrive/token.rb
@@ -4,16 +4,16 @@ module Skydrive
     belongs_to :user
 
     def requires_refresh?
-      !!self.not_before && self.not_before < Time.now
+      !!(self.not_before && !self.not_before.is_a?(Time) && self.not_before < Time.now)
     end
 
     def is_valid?
       !!self.access_token && self.expires_on && self.expires_on > Time.now
     end
 
-    def refresh!(client)
+    def refresh!
       results = {}
-      results = client.refresh_token(resource: resource)
+      results = self.user.skydrive_client.update_api_tokens(resource: resource, refresh_token: refresh_token, token: access_token)
       if results.key? 'access_token'
         attrs = ['token_type', 'expires_in', 'expires_on', 'not_before', 'resource', 'access_token', 'refresh_token']
         update_attributes(results.reject{|a| !attrs.include?(a)})

--- a/lib/skydrive.rb
+++ b/lib/skydrive.rb
@@ -1,6 +1,24 @@
 require "skydrive/engine"
 
 module Skydrive
+
+
+  class OAuthStateException < RuntimeError
+  end
+
+  class APIErrorException < RuntimeError
+  end
+
+  class APIResponseErrorException < RuntimeError
+    attr_reader :response, :code, :description
+    def initialize(response)
+      @response = response
+      @code = response['error']
+      @description = response['error_description']
+      super("#{@code}: #{@description}\n#{response}")
+    end
+  end
+
   class << self
     attr_accessor :logger
   end

--- a/spec/controllers/launch_controller_spec.rb
+++ b/spec/controllers/launch_controller_spec.rb
@@ -188,7 +188,6 @@ module Skydrive
 
       it "returns a skydrive_auth url when the skydrive token is invalid" do
         user.save
-        user.token = Token.create()
 
         allow_any_instance_of(LaunchController).to receive(:current_user).and_return(user)
 
@@ -199,7 +198,7 @@ module Skydrive
 
       it "returns a 200 when the skydrive token is valid" do
         user.save
-        user.token = Token.create(access_token: 'token', expires_on: 1.week.from_now)
+        user.token.update_attributes(access_token: 'token', expires_on: 1.week.from_now)
 
         allow_any_instance_of(LaunchController).to receive(:current_user).and_return(user)
 

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+module Skydrive
+  describe Token do
+    let(:user) {User.create(:email => 'email@email.com', username: 'user', name: 'User')}
+    it "requires_refresh? shouldn't be true when empty" do
+      token = Token.create(user: user)
+      expect(token.requires_refresh?).to be(false)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+module Skydrive
+  describe User do
+    it "creates token if one doesnt exist" do
+      user = User.create(:email => 'email@email.com', username: 'user', name: 'User')
+      expect(user.token).to be_a(Token)
+    end
+  end
+end


### PR DESCRIPTION
the user model is now responsible for keeping the token up to date. we
should no longer have to call token.refresh!

moved cleanup_api_keys to be and after_initialize on the user model

Added some test for the user and token models

Client instantiation should only happen inside the user object
ApplicationController will pull the skydrive_client from the user
instead of magically creating one for it.

Made logging prod friendly

Moved exceptions to a more sane place, so all the codes can access it

Fixed a bug in Token.requires_refresh? where it would return true if it
was empty.

Changed confusing method name from refresh_token to update_api_tokens
since we also have an attribute named refresh_token on both the client
and token